### PR TITLE
Allow hooks object for client creation

### DIFF
--- a/cohort_1/week2_question_classification/classify_with_yaml/yaml_classifier.py
+++ b/cohort_1/week2_question_classification/classify_with_yaml/yaml_classifier.py
@@ -4,7 +4,7 @@ from pydantic import field_validator
 from instructor import Instructor, AsyncInstructor
 from jinja2 import Template
 from textwrap import dedent
-from typing import Type, TypeVar
+from typing import Type, TypeVar, Any
 
 T = TypeVar("T", bound=BaseModel)
 
@@ -115,35 +115,51 @@ class YamlClassifier(BaseModel):
         self._client = client
 
     def predict(
-        self, query: str, model: str, response_model: Type[T], client: Instructor
+        self,
+        query: str,
+        model: str,
+        response_model: Type[T],
+        client: Instructor,
+        hooks: Any | None = None,
     ):
         system_message = self.to_system_messages()
         user_query = self.get_user_query(query)
-        return client.create(
-            model=model,
-            response_model=response_model,
-            messages=[
+        kwargs = {
+            "model": model,
+            "response_model": response_model,
+            "messages": [
                 {"role": "system", "content": system_message},
                 {"role": "user", "content": user_query},
             ],
-            validation_context={
+            "validation_context": {
                 "labels": self.get_labels(),
             },
-        )
+        }
+        if hooks is not None:
+            kwargs["hooks"] = hooks
+        return client.create(**kwargs)
 
     async def apredict(
-        self, query: str, model: str, response_model: Type[T], client: AsyncInstructor
+        self,
+        query: str,
+        model: str,
+        response_model: Type[T],
+        client: AsyncInstructor,
+        hooks: Any | None = None,
     ):
         system_message = self.to_system_messages()
         user_query = self.get_user_query(query)
-        return await client.create(
-            messages=[
+        kwargs = {
+            "messages": [
                 {"role": "system", "content": system_message},
                 {"role": "user", "content": user_query},
             ],
-            model=model,
-            response_model=response_model,
-            validation_context={
+            "model": model,
+            "response_model": response_model,
+            "validation_context": {
                 "labels": self.get_labels(),
             },
-        )
+        }
+        if hooks is not None:
+            kwargs["hooks"] = hooks
+        return await client.create(**kwargs)

--- a/latest/case_study/core/summarization.py
+++ b/latest/case_study/core/summarization.py
@@ -16,6 +16,7 @@ class ConversationSummary(BaseModel):
 async def conversation_summary_v1(
     client,  # instructor-patched client
     messages: List[Dict[str, Any]],
+    hooks: Any | None = None,
 ) -> ConversationSummary:
     """
     Generate a concise summary focused on key topics and searchable terms.
@@ -61,12 +62,15 @@ async def conversation_summary_v1(
     Generate a concise, searchable summary of this conversation.
     """
 
-    response = await client.chat.completions.create(
-        response_model=ConversationSummary,
-        messages=[{"role": "user", "content": prompt}],
-        context={"messages": messages},
-        max_retries=3,
-    )
+    kwargs = {
+        "response_model": ConversationSummary,
+        "messages": [{"role": "user", "content": prompt}],
+        "context": {"messages": messages},
+        "max_retries": 3,
+    }
+    if hooks is not None:
+        kwargs["hooks"] = hooks
+    response = await client.chat.completions.create(**kwargs)
 
     return response
 
@@ -74,6 +78,7 @@ async def conversation_summary_v1(
 async def conversation_summary_v2(
     client,  # instructor-patched client
     messages: List[Dict[str, Any]],
+    hooks: Any | None = None,
 ) -> ConversationSummary:
     """
     Generate a comprehensive summary that captures conversation patterns, themes, and user interaction dynamics.
@@ -278,18 +283,21 @@ Please provide your summary based on the conversation so far, following this str
 {% endfor %}
     """
 
-    response = await client.chat.completions.create(
-        response_model=ConversationSummary,
-        messages=[
+    kwargs = {
+        "response_model": ConversationSummary,
+        "messages": [
             {
                 "role": "system",
                 "content": "You are an expert at analyzing and categorizing human-AI conversations, focusing on patterns, themes, interaction characteristics, and user experience dynamics across all types of conversations.",
             },
             {"role": "user", "content": prompt},
         ],
-        context={"messages": messages},
-        max_retries=3,
-    )
+        "context": {"messages": messages},
+        "max_retries": 3,
+    }
+    if hooks is not None:
+        kwargs["hooks"] = hooks
+    response = await client.chat.completions.create(**kwargs)
 
     return response
 
@@ -297,6 +305,7 @@ Please provide your summary based on the conversation so far, following this str
 async def conversation_summary_v3(
     client,  # instructor-patched client
     messages: List[Dict[str, Any]],
+    hooks: Any | None = None,
 ) -> ConversationSummary:
     """
     Generate a concise pattern-focused summary that bridges content and patterns.
@@ -361,18 +370,21 @@ Focus on creating a summary that works for BOTH content searches AND pattern sea
 Generate a concise, pattern-aware summary that balances content and conversation dynamics.
     """
 
-    response = await client.chat.completions.create(
-        response_model=ConversationSummary,
-        messages=[
+    kwargs = {
+        "response_model": ConversationSummary,
+        "messages": [
             {
                 "role": "system",
                 "content": "You are an expert at creating concise summaries that capture both what was discussed and how the conversation unfolded. Balance pattern recognition with content summary.",
             },
             {"role": "user", "content": prompt},
         ],
-        context={"messages": messages},
-        max_retries=3,
-    )
+        "context": {"messages": messages},
+        "max_retries": 3,
+    }
+    if hooks is not None:
+        kwargs["hooks"] = hooks
+    response = await client.chat.completions.create(**kwargs)
 
     return response
 
@@ -380,6 +392,7 @@ Generate a concise, pattern-aware summary that balances content and conversation
 async def conversation_summary_v4(
     client,  # instructor-patched client
     messages: List[Dict[str, Any]],
+    hooks: Any | None = None,
 ) -> ConversationSummary:
     """
     Generate a pattern-focused summary optimized for v2-style queries.
@@ -461,18 +474,21 @@ Remember: Focus on HOW the conversation unfolds and WHAT TYPE it represents, not
 Generate a pattern-focused summary that would be discoverable by researchers looking for specific conversation types and interaction patterns.
 """
 
-    response = await client.chat.completions.create(
-        response_model=ConversationSummary,
-        messages=[
+    kwargs = {
+        "response_model": ConversationSummary,
+        "messages": [
             {
                 "role": "system",
                 "content": "You are an expert at categorizing conversations by their patterns, types, and interaction dynamics. Focus on creating summaries that match how researchers search for conversation patterns rather than specific content.",
             },
             {"role": "user", "content": prompt},
         ],
-        context={"messages": messages},
-        max_retries=3,
-    )
+        "context": {"messages": messages},
+        "max_retries": 3,
+    }
+    if hooks is not None:
+        kwargs["hooks"] = hooks
+    response = await client.chat.completions.create(**kwargs)
 
     return response
 
@@ -480,6 +496,7 @@ Generate a pattern-focused summary that would be discoverable by researchers loo
 async def conversation_summary_v5(
     client,  # instructor-patched client
     messages: List[Dict[str, Any]],
+    hooks: Any | None = None,
 ) -> ConversationSummary:
     """
     Generate summaries optimized for AI agent failure analysis and improvement identification.
@@ -539,17 +556,20 @@ async def conversation_summary_v5(
     Generate a balanced summary optimized for both pattern and content queries.
     """
 
-    response = await client.chat.completions.create(
-        response_model=ConversationSummary,
-        messages=[
+    kwargs = {
+        "response_model": ConversationSummary,
+        "messages": [
             {
                 "role": "system",
                 "content": "You are an expert at analyzing AI conversations for system improvement. Focus on identifying failure patterns, root causes, and specific opportunities for enhancement. Your summaries should enable data-driven decisions about where to invest development effort.",
             },
             {"role": "user", "content": prompt},
         ],
-        context={"messages": messages},
-        max_retries=3,
-    )
+        "context": {"messages": messages},
+        "max_retries": 3,
+    }
+    if hooks is not None:
+        kwargs["hooks"] = hooks
+    response = await client.chat.completions.create(**kwargs)
 
     return response


### PR DESCRIPTION
Add support for per-call `hooks` in `yaml_classifier` and summarization functions to enable granular hook management.

---
<a href="https://cursor.com/background-agent?bcId=bc-bd6dabd3-ae09-4453-8b7e-204061afc4f9">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-bd6dabd3-ae09-4453-8b7e-204061afc4f9">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

